### PR TITLE
add docker-compose 1.6.0 and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tools of the trade
   - tmux 2.1
   - docker-compose 1.6.0
   - zsh 5.0.8 + prezto (OMZ)
+  - zsh completions for docker and docker-compose
 
 
 ![alt text](https://raw.githubusercontent.com/wharsojo/assets/master/myboot2docker/myboot2docker.gif "My Boot2Docker Demo")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools of the trade
 ------------------
 
   - tmux 2.1
-  - docker-compose 1.5.2
+  - docker-compose 1.6.0
   - zsh 5.0.8 + prezto (OMZ)
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools of the trade
 ------------------
 
   - tmux 2.1
-  - docker-compose 1.4.2
+  - docker-compose 1.5.2
   - zsh 5.0.8 + prezto (OMZ)
 
 


### PR DESCRIPTION
Forgot to update readme in my previous PR.

And.. 1.5.2 again contains a `ctrl-c` regression, I'm sorry that I didn't really test it thoroughly before sending the PR.
I'll send another PR once a new version of docker-compose that fixes the regression is released.

@wharsojo thanks
